### PR TITLE
fix schedule changeover bug

### DIFF
--- a/pagerduty/schedules.go
+++ b/pagerduty/schedules.go
@@ -93,9 +93,9 @@ func updateScheduleListFromResponse(a *Api, res *pagerduty.ListSchedulesResponse
 				p.User = se.User.ID
 				schd.NextPeriod = &p
 			}
-
-			*schdList = append(*schdList, *schd)
 		}
+
+		*schdList = append(*schdList, *schd)
 
 		lf := log.Fields{
 			"id": schd.Id,


### PR DESCRIPTION
accidentally adding multiple schedules to the list, where we should have
had one schedule per, uh, pagerduty schedule.

the first entry had no NextPeriod set, so I the bug was it wouldn't
update until the previous person's period dropped off the _today_ list.