### PR TITLE
feat: add new Growth Eng, Supply Chain Eng, and HighJump Eng aliases

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,6 +17,14 @@ groups:
   - name: it-help
     schedules:
       - PBC8G5I
+  - name: growth-engineering-help
+    schedules:
+      - PLK5L2Y
+  - name: supply-chain-engineering-help
+    schedules:
+      - PIMQ3SN
+  # TODO(serhalp) Remove these two as part of cleanup step of
+  # https://www.pivotaltracker.com/story/show/178790883.
   - name: application-engineering-help
     schedules:
       - P61VATU

--- a/config.yml
+++ b/config.yml
@@ -17,6 +17,9 @@ groups:
   - name: it-help
     schedules:
       - PBC8G5I
+  - name: highjump-engineering-help
+    schedules:
+      - POR5IQ1
   - name: growth-engineering-help
     schedules:
       - PLK5L2Y


### PR DESCRIPTION
### feat: add new Growth Eng and Supply Chain Eng aliases

We are splitting the App Eng rotation into separate teams and eliminating the concept of 'secondary'. See https://www.pivotaltracker.com/story/show/178790883.

The Slack aliases have already been created.

I'll remove the legacy aliases in a future PR.

[#178790883]

 ### feat: add HighJump Engineering alias

Bonus request from Michael. We are creating this rotation soon, so we're throwing this in while I'm here.

The Slack alias has already been created.