### PR TITLE
fix Travis

### DIFF
--- a/.ranch.yaml
+++ b/.ranch.yaml
@@ -4,6 +4,6 @@ name: pagerbot
 
 processes:
   pagerbot:
-    command: /pagerbot
+    command: ./pagerbot
     count: 1
     memory: 64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: trusty
-sudo: required
+# Necessary to work around a cert error 🤷
+dist: bionic
 
 language: bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,2 @@
-FROM bitnami/minideb:stretch
-RUN install_packages ca-certificates
-COPY dist/linux_amd64/pagerbot config.yml /
-CMD ["/pagerbot"]
+FROM goodeggs/platform-base:2.6.0
+COPY --chown=docker:docker dist/linux_amd64/pagerbot config.yml ./

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,1 +1,15 @@
-FROM goodeggs/dataland-go:runner
+FROM goodeggs/platform-base:2.6.0 as development
+
+ARG GO_IMPORT_PATH
+ENV GOPATH=/gopath
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+WORKDIR /gopath/src/${GO_IMPORT_PATH}
+RUN true \
+  && install_packages build-essential \
+  && chown -R docker:docker /gopath \
+  && mkdir /.cache \
+  && chown docker:docker /.cache
+
+COPY --chown=docker:docker .go-version ./
+# Golang download paths don't include patch level 0!
+RUN curl -sSL "https://dl.google.com/go/go$(cat .go-version | sed 's/[.]0$//').linux-amd64.tar.gz" | sudo tar -C /usr/local -xz

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,10 @@ SHELL=/bin/bash -o pipefail
 BIN=pagerbot
 GO_FLAGS=-ldflags "-extldflags '-static'"
 
-DOCKER_FLAGS=-u $$(id -u):$$(id -g)
-RUNNER=docker-compose exec -T $(DOCKER_FLAGS) runner
+RUNNER=docker-compose exec -T runner
 
 shell: docker-up
-	docker-compose exec $(DOCKER_FLAGS) runner bash
+	docker-compose exec runner bash
 
 test: docker-up
 	@$(RUNNER) go test -v ./...
@@ -20,8 +19,7 @@ clean:
 
 docker-up:
 	@(env -i bash --noprofile --norc -c '. platform/secrets/ci.env; env') | grep -v '^PWD=' > .ci-runner.env
-	@env | ( grep DOCKER_ || true ) >> .ci-runner.env
-	@FIXUID=$$(id -u) FIXGID=$$(id -g) docker-compose up -d
+	docker-compose up -d
 	@$(RUNNER) go get github.com/mitchellh/gox
 
 build: docker-up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    image: goodeggs/pagerbot:runner
     working_dir: /app
-    entrypoint: ["fixuid"]
     command: ["sh", "-c", "echo 'READY PLAYER ONE'; sleep 90000"]
-    user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
-      - ${HOME}:${HOME}
       - .:/app
-      - /var/run/docker.sock:/var/run/docker.sock
     env_file:
       - .ci-runner.env

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 // indirect
 	github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6 // indirect
-	github.com/mitchellh/gox v0.4.0 // indirect
-	github.com/mitchellh/iochan v1.0.0 // indirect
+	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/nlopes/slack v0.2.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v0.0.0-20160524234229-8d64eb7173c7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -19,6 +21,8 @@ github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6 h1:iOAVXzZyXtW408
 github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6/go.mod h1:sFlOUpQL1YcjhFVXhg1CG8ZASEs/Mf1oVb6H75JL/zg=
 github.com/mitchellh/gox v0.4.0 h1:lfGJxY7ToLJQjHHwi0EX6uYBdK78egf954SQl13PQJc=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/nlopes/slack v0.2.0 h1:ygNVH3HWrOPFbzFoAmRKPcMcmYMmsLf+vPV9DhJdqJI=


### PR DESCRIPTION
Travis builds started failing with cert errors, apparently from an outdated distro in our Docker images.  This PR switches to our standard platform-base image which does not have the same problem.
